### PR TITLE
Fix: Use  for _id in sales by category aggregation to handle missing …

### DIFF
--- a/backend/controllers/adminController.js
+++ b/backend/controllers/adminController.js
@@ -185,7 +185,7 @@ const getSalesByCategory = asyncHandler(async (req, res) => {
         { $unwind: '$categoryDetails' },
         {
             $group: {
-                _id: '$categoryDetails.name',
+                _id: { $ifNull: ['$categoryDetails.name', 'Unknown Category'] },
                 totalRevenue: { $sum: { $multiply: ['$orderItems.qty', '$orderItems.price'] } },
                 totalSold: { $sum: '$orderItems.qty' },
             },


### PR DESCRIPTION
…category names